### PR TITLE
Update acorn for ECMAScript 2020 features

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = isExpression;
 var DEFAULT_OPTIONS = {
   throw: false,
   strict: false,
-  lineComment: false
+  lineComment: false,
+  ecmaVersion: 2020,
 };
 
 function isExpression(src, options) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var DEFAULT_OPTIONS = {
   throw: false,
   strict: false,
   lineComment: false,
-  ecmaVersion: 2020,
+  ecmaVersion: 2020
 };
 
 function isExpression(src, options) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "expression"
   ],
   "dependencies": {
-    "acorn": "^7.1.1",
+    "acorn": "^8.0.1",
     "object-assign": "^4.1.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -18,6 +18,7 @@ testit('passes', function () {
   passes('abc // my comment', {lineComment: true});
   passes('() => a');
   passes('function (a = "default") {"use strict";}', {ecmaVersion: 6});
+  passes('5 ?? 6');
 });
 
 function error(src, line, col, options) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,10 +197,10 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-acorn@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+acorn@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.1.tgz#d7e8eca9b71d5840db0e7e415b3b2b20e250f938"
+  integrity sha512-dmKn4pqZ29iQl2Pvze1zTrps2luvls2PBY//neO2WJ0s10B3AxJXshN+Ph7B4GrhfGhHXrl4dnUwyNNXQcnWGQ==
 
 aggregate-error@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
This updates acorn to the latest version, specifies a default `ecmaVersion` which is required now and a test for the nullish coalescing operator which is the reason for this pull request.

I'm hoping for a bump in pug-lexer and pug too, so that we can use the new features in our templates.

Being able to `div= 5 ?? 6` would shrink my templates immensely.